### PR TITLE
#80 añadir información conductor

### DIFF
--- a/ppf/common/models/user.py
+++ b/ppf/common/models/user.py
@@ -115,7 +115,7 @@ class Driver(User):
     # Preferences attributes
     preference = models.OneToOneField("Preference", on_delete=models.CASCADE)
 
-    iban = models.CharField(max_length=36, unique=True)
+    iban = models.CharField(max_length=36, unique=True, null=True, blank=True)
 
     class Meta:
         """


### PR DESCRIPTION
Resolve Issue "Driver field IBAN is Not Nullable without default #23"
The "iban" field is set to null=true and blank=true. Now it is mandatory to fill the "iban" field, but for the next sprint it will be optional and can be fill in edit profile screen. I let the blank=true, because for this sprint it is controlled by the frontend.
I can remove blank=true and add it in the next sprint or leave it and it will be ready for the next sprint.